### PR TITLE
docs: add site migration baseline

### DIFF
--- a/.github/workflows/site-compatibility.yml
+++ b/.github/workflows/site-compatibility.yml
@@ -1,0 +1,22 @@
+name: Site compatibility
+
+on:
+  pull_request:
+    branches:
+      - version-1.1
+    paths:
+      - "docs/**"
+      - "maintainers/site-migration.md"
+      - "mkdocs.yml"
+      - "scripts/check_site_paths.py"
+      - ".github/workflows/site-compatibility.yml"
+jobs:
+  check-site-paths:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Check source path compatibility
+        run: python scripts/check_site_paths.py

--- a/maintainers/site-migration.md
+++ b/maintainers/site-migration.md
@@ -1,0 +1,97 @@
+# Site Migration Notes
+
+This document records the public URL and deployment constraints for the
+`iscc.codes` documentation site during the migration from MkDocs to Zensical.
+It is intended for maintainers. The goal is continuity: existing links should
+continue to work, and old entry points should either remain useful pages or
+forward to the most relevant replacement.
+
+## Current deployment
+
+- Public site: <https://iscc.codes/>
+- Custom domain: `iscc.codes`
+- GitHub repository: `iscc/iscc-specs`
+- Documentation source branch for the current site: `version-1.1`
+- Published GitHub Pages branch: `gh-pages`
+- GitHub Pages source: `gh-pages` branch, repository root
+- Custom domain file: `docs/CNAME` in the source branch and `CNAME` in the
+  generated `gh-pages` branch
+
+## Current public paths
+
+The current sitemap lists these canonical paths:
+
+- `/`
+- `/concept/`
+- `/features/`
+- `/license/`
+- `/resources/`
+- `/specification/`
+
+These paths should remain valid throughout the migration. If a page is moved as
+part of the new information architecture, keep the old path as a forwarding page
+or configure an explicit redirect to the new location.
+
+## Historical and compatibility paths
+
+The current MkDocs configuration contains this redirect:
+
+- `/implementations/` → `/resources/`
+
+Keep this compatibility path covered in the Zensical migration. It may become a
+redirect to a future implementations, ecosystem, or developer-resources page,
+but it should not become a bare 404.
+
+## Source path mapping
+
+Current source files for the public paths:
+
+- `/` → `docs/index.md`
+- `/concept/` → `docs/concept.md`
+- `/features/` → `docs/features.md`
+- `/license/` → `docs/license.md`
+- `/resources/` → `docs/resources.md`
+- `/specification/` → `docs/specification.md`
+- `/implementations/` → compatibility redirect currently configured in
+  `mkdocs.yml`
+
+## Migration rules
+
+- Preserve the custom domain `iscc.codes`.
+- Preserve all current public paths listed above.
+- Preserve `/implementations/` as a compatibility path.
+- Prefer neutral maintainer vocabulary such as "site migration", "URL
+  preservation", "link compatibility", "redirect map", and "canonical paths".
+- Avoid repository structure or public docs that frame this work as marketing.
+- Keep early migration pull requests mechanical and reviewable: first preserve
+  paths, then change the documentation engine, then update stale content.
+- Treat the old Python implementation as historical POC code until a dedicated
+  retirement/archive change handles it.
+
+## Verification
+
+Run the source compatibility check from the repository root:
+
+```bash
+python scripts/check_site_paths.py
+```
+
+After generating a site, pass the output directory as well:
+
+```bash
+python scripts/check_site_paths.py --site-dir site
+```
+
+The check verifies that required source pages exist and, when a generated site
+is provided, that the generated output still contains the required public paths.
+
+## Notes for future Zensical migration
+
+When the MkDocs configuration is replaced with `zensical.toml`, carry over the
+same compatibility requirements:
+
+- Define navigation or page sources for the six canonical paths.
+- Add an explicit redirect or forwarding page for `/implementations/`.
+- Keep `docs/CNAME` or the equivalent Pages custom-domain configuration.
+- Re-run `scripts/check_site_paths.py` against the generated output before
+  publishing.

--- a/scripts/check_site_paths.py
+++ b/scripts/check_site_paths.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Check URL compatibility requirements for the iscc.codes site.
+
+The script intentionally uses only the Python standard library so it can run in
+GitHub Actions before the documentation toolchain is installed. By default it
+checks source files. With ``--site-dir`` it also checks generated output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+REQUIRED_SOURCE_PATHS = {
+    "/": Path("docs/index.md"),
+    "/concept/": Path("docs/concept.md"),
+    "/features/": Path("docs/features.md"),
+    "/license/": Path("docs/license.md"),
+    "/resources/": Path("docs/resources.md"),
+    "/specification/": Path("docs/specification.md"),
+}
+
+# Historical path currently handled by mkdocs-redirects.
+COMPATIBILITY_PATHS = ("/implementations/",)
+
+
+def generated_index_for(site_dir: Path, url_path: str) -> Path:
+    """Return the expected generated index.html file for a canonical path."""
+    if url_path == "/":
+        return site_dir / "index.html"
+    return site_dir / url_path.strip("/") / "index.html"
+
+
+def check_source_files(repo_root: Path) -> list[str]:
+    """Verify that required source pages and migration notes exist."""
+    errors: list[str] = []
+
+    for url_path, source_path in REQUIRED_SOURCE_PATHS.items():
+        absolute_path = repo_root / source_path
+        if not absolute_path.is_file():
+            errors.append(f"missing source for {url_path}: {source_path}")
+
+    migration_notes = repo_root / "maintainers/site-migration.md"
+    if not migration_notes.is_file():
+        errors.append("missing maintainer migration notes: maintainers/site-migration.md")
+
+    cname = repo_root / "docs/CNAME"
+    if not cname.is_file():
+        errors.append("missing custom domain file: docs/CNAME")
+    elif cname.read_text(encoding="utf-8").strip() != "iscc.codes":
+        errors.append("docs/CNAME must contain exactly: iscc.codes")
+
+    mkdocs_config = repo_root / "mkdocs.yml"
+    if mkdocs_config.is_file():
+        mkdocs_text = mkdocs_config.read_text(encoding="utf-8")
+        redirect_pattern = re.compile(
+            r"['\"]?implementations\.md['\"]?\s*:\s*['\"]?resources\.md['\"]?"
+        )
+        if redirect_pattern.search(mkdocs_text) is None:
+            errors.append("mkdocs.yml should preserve implementations.md -> resources.md redirect")
+
+    return errors
+
+
+def check_generated_site(site_dir: Path) -> list[str]:
+    """Verify generated output paths when a site directory is available."""
+    errors: list[str] = []
+
+    if not site_dir.is_dir():
+        return [f"site directory does not exist: {site_dir}"]
+
+    for url_path in REQUIRED_SOURCE_PATHS:
+        index_file = generated_index_for(site_dir, url_path)
+        if not index_file.is_file():
+            errors.append(f"missing generated page for {url_path}: {index_file}")
+
+    for url_path in COMPATIBILITY_PATHS:
+        index_file = generated_index_for(site_dir, url_path)
+        if not index_file.is_file():
+            errors.append(f"missing generated compatibility path for {url_path}: {index_file}")
+
+    cname = site_dir / "CNAME"
+    if not cname.is_file():
+        errors.append(f"missing generated custom domain file: {cname}")
+    elif cname.read_text(encoding="utf-8").strip() != "iscc.codes":
+        errors.append("generated CNAME must contain exactly: iscc.codes")
+
+    return errors
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root to check. Defaults to the current working directory.",
+    )
+    parser.add_argument(
+        "--site-dir",
+        type=Path,
+        help="Optional generated site directory to check, for example 'site'.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+
+    errors = check_source_files(repo_root)
+    if args.site_dir is not None:
+        site_dir = args.site_dir
+        if not site_dir.is_absolute():
+            site_dir = repo_root / site_dir
+        errors.extend(check_generated_site(site_dir.resolve()))
+
+    if errors:
+        print("Site path compatibility check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print("Site path compatibility check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add maintainer-facing site migration notes for the current `iscc.codes` deployment and public path inventory.
- Add a standard-library compatibility check for required source pages, custom domain configuration, redirect coverage, and optional generated output checks.
- Add a minimal GitHub Actions workflow for PRs targeting `version-1.1` when site source/configuration changes.

## Notes
- The migration notes live in `maintainers/`, outside the MkDocs `docs/` tree, so they are repository-maintainer documentation and are not published to the site.
- This deliberately uses neutral site-maintenance vocabulary: URL preservation, link compatibility, redirect map, canonical paths.

## Test Plan
- [x] `python scripts/check_site_paths.py`
- [x] `python -m py_compile scripts/check_site_paths.py`
- [x] `python scripts/check_site_paths.py --site-dir <gh-pages worktree>`
- [x] `git diff --cached --check`
- [x] Independent review with Claude Code/Codex CLI