### PR TITLE
docs: update repository metadata after rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ISCC - Spec and Reference Code
 
-[![Build](https://github.com/iscc/iscc-specs/actions/workflows/test.yml/badge.svg?branch=version-1.1)](https://github.com/iscc/iscc-specs/actions/workflows/test.yml)
+[![Build](https://github.com/iscc/iscc-codes/actions/workflows/test.yml/badge.svg?branch=version-1.1)](https://github.com/iscc/iscc-codes/actions/workflows/test.yml)
 [![License](https://img.shields.io/pypi/l/iscc.svg)](https://pypi.python.org/pypi/iscc/)
 [![Downloads](https://pepy.tech/badge/iscc)](https://pepy.tech/project/iscc)
 [![DOI](https://zenodo.org/badge/96668860.svg)](https://zenodo.org/badge/latestdoi/96668860)
@@ -73,17 +73,17 @@ A short example on how to create an ISCC Code with the reference implementation.
 The entire **ISCC Specification** is written in plain text [Markdown](https://en.wikipedia.org/wiki/Markdown). The markdown content is than built and published with the excellent [mkdocs](http://www.mkdocs.org/) documetation tool. If you have some basic command line skills you can build and run the specification site on your own computer. Make sure you have the [git](https://git-scm.com/) and [Python](https://www.python.org/) and [Poetry](https://pypi.org/project/poetry/) installed on your system and follow these steps on the command line:
 
 ``` bash
-git clone https://github.com/iscc/iscc-specs.git
-cd iscc-specs
+git clone https://github.com/iscc/iscc-codes.git
+cd iscc-codes
 poetry install
 mkdocs serve
 ```
 
-All specification documents can be found in the `./docs` subfolder or the repository. The recommended editor for the markdown files is [Typora](https://typora.io/). If you have commit rights to the [main repository](https://github.com/iscc/iscc-specs) you can deploy the site with a simple `mkdocs gh-deploy`.
+All specification documents can be found in the `./docs` subfolder or the repository. The recommended editor for the markdown files is [Typora](https://typora.io/). If you have commit rights to the [main repository](https://github.com/iscc/iscc-codes) you can deploy the site with a simple `mkdocs gh-deploy`.
 
 ## Contribute
 
-Pull requests and other contributions are welcome. Use the [Github Issues](https://github.com/iscc/iscc-specs/issues) section of this project to discuss ideas for the **ISCC Specification**. You may also want  join our developer chat on Telegram at <https://t.me/iscc_dev>.
+Pull requests and other contributions are welcome. Use the [Github Issues](https://github.com/iscc/iscc-codes/issues) section of this project to discuss ideas for the **ISCC Specification**. You may also want  join our developer chat on Telegram at <https://t.me/iscc_dev>.
 
 ## License
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -4,21 +4,21 @@ authors: Titusz Pan
 
 # ISCC - Resources
 
-If you find something that is missing from this collection of resources for the ISCC, [please add it](https://github.com/iscc/iscc-specs/edit/master/docs/resources.md).
+If you find something that is missing from this collection of resources for the ISCC, [please add it](https://github.com/iscc/iscc-codes/edit/version-1.1/docs/resources.md).
 
 ## ISCC - Official Software & Tools
 
 ### [ISCC - CLI](https://github.com/iscc/iscc-cli)
 
-An open-source command-line tool that can be used on **Windows**, **Linux**, and **Mac** systems by developers and computer savvy persons to create ISCC codes from media files and URLs. The tool is based on the [reference implementation](https://github.com/iscc/iscc-specs) but also includes **new and experimental features** (e.g., Audio-Codes, Video-Codes) that are not yet part of the [public specification](https://iscc.codes/specification/).
+An open-source command-line tool that can be used on **Windows**, **Linux**, and **Mac** systems by developers and computer savvy persons to create ISCC codes from media files and URLs. The tool is based on the [reference implementation](https://github.com/iscc/iscc-codes) but also includes **new and experimental features** (e.g., Audio-Codes, Video-Codes) that are not yet part of the [public specification](https://iscc.codes/specification/).
 
 ### [ISCC - Web Service](https://github.com/iscc/iscc-service)
 
-A REST OpenAPI backend service application for creating [**ISCC codes**](https://iscc.codes/) for digital media files and URLs. The Webservice is built with [FastAPI](https://github.com/tiangolo/fastapi) and makes use of the [ISCC reference implementation](https://github.com/iscc/iscc-specs) and the [ISCC Command Line Tool](https://github.com/iscc/iscc-cli) and includes interactive API documentation.
+A REST OpenAPI backend service application for creating [**ISCC codes**](https://iscc.codes/) for digital media files and URLs. The Webservice is built with [FastAPI](https://github.com/tiangolo/fastapi) and makes use of the [ISCC reference implementation](https://github.com/iscc/iscc-codes) and the [ISCC Command Line Tool](https://github.com/iscc/iscc-cli) and includes interactive API documentation.
 
-### [ISCC - Specification & Reference Implementation](https://github.com/iscc/iscc-specs)
+### [ISCC - Specification & Reference Implementation](https://github.com/iscc/iscc-codes)
 
-The official ISCC reference implementation. The reference code is published on the [Python Package Index](https://pypi.org/project/iscc/) and can be installed as a library by developers. The ISCC specification is written in markdown and hosted in the same [source code repository](https://github.com/iscc/iscc-specs) and published at [http://iscc.codes/specification](https://iscc.codes/specification/). For contributions and public discussions, please use the corresponding [issue tracker](https://github.com/iscc/iscc-specs/issues).
+The official ISCC reference implementation. The reference code is published on the [Python Package Index](https://pypi.org/project/iscc/) and can be installed as a library by developers. The ISCC specification is written in markdown and hosted in the same [source code repository](https://github.com/iscc/iscc-codes) and published at [https://iscc.codes/specification](https://iscc.codes/specification/). For contributions and public discussions, please use the corresponding [issue tracker](https://github.com/iscc/iscc-codes/issues).
 
 ## ISCC - Third-Party Implementations
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -16,11 +16,11 @@ The **International Standard Content Code (ISCC)**, is an open and decentralized
 
 ## Note to Readers
 
-For public discussion of issues for this specification, please use the Github issue tracker: <https://github.com/iscc/iscc-specs/issues>.
+For public discussion of issues for this specification, please use the Github issue tracker: <https://github.com/iscc/iscc-codes/issues>.
 
 If you want to chat with developers, join us on Telegram at <https://t.me/iscc_dev>.
 
-You can find the latest version of this specification at <http://iscc.codes/specification/>.
+You can find the latest version of this specification at <https://iscc.codes/specification/>.
 
 Public review, discussion and contributions are welcome.
 
@@ -28,7 +28,7 @@ Public review, discussion and contributions are welcome.
 
 !!! note "Document Version"
 
-    While there is already a [Version 1.0](https://github.com/iscc/iscc-specs/blob/version-1.0/docs/specification.md) spec, we are still expecting backward incompatible changes until **Version 2.0**. Parts of this specification may become stable earlier. We will document this during minor releases. We encourage partners to follow development and test, implement, and give feedback based on the latest (this) version of the ISCC Specification.
+    While there is already a [Version 1.0](https://github.com/iscc/iscc-codes/blob/version-1.0/docs/specification.md) spec, we are still expecting backward incompatible changes until **Version 2.0**. Parts of this specification may become stable earlier. We will document this during minor releases. We encourage partners to follow development and test, implement, and give feedback based on the latest (this) version of the ISCC Specification.
 
 This document proposes an open and vendor neutral ISCC standard and describes the technical procedures to create and manage ISCC identifiers. The first version of this document resulted from a prototyping project by the [Content Blockchain Project](https://content-blockchain.org) and received funding from the [Google Digital News Initiative (DNI)](https://digitalnewsinitiative.com/dni-projects/content-blockchain-project/). The content of this document results from a voluntary effort of the authors with an open and public consensus process.
 
@@ -172,7 +172,7 @@ An ISCC generating application must follow these steps in the given order to pro
 9. Return encoded Meta-Code, trimmed `title` and trimmed `extra` data.
 
 
-See also: [Meta-Code reference code](https://github.com/iscc/iscc-specs/blob/master/src/iscc/iscc.py#L19)
+See also: [Meta-Code reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L19)
 
 !!! warning "Text trimming"
     When trimming text be sure to trim the byte-length of the UTF-8 encoded version and not the number of characters. The trim point MUST be such that it does not cut into multi-byte characters. Characters might have different UTF-8 byte-length. For example `ü` is 2-bytes, `驩` is 3-bytes and `𠜎` is 4-bytes. So the trimmed version of a string with 128 `驩`-characters will result in a 42-character string with a 126-byte UTF-8 encoded length. This is necessary because the results of this operation will be stored as basic metadata with strict byte size limits on the blockchain.
@@ -226,7 +226,7 @@ An ISCC generating application MUST provide a `content_id(text, partial=False)` 
 7. Prepend the 1-byte component header (`0x10` full content or `0x11` partial content).
 8. Encode and return the resulting 9-byte sequence with [`encode`](#encode).
 
-See also: [Content-Code-Text reference code](https://github.com/iscc/iscc-specs/blob/master/src/iscc/iscc.py#L54)
+See also: [Content-Code-Text reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L54)
 
 #### Content-Code-Image
 
@@ -239,7 +239,7 @@ An ISCC generating application MUST provide a `content_id_image(image, partial=F
 3. Prepend the 1-byte component header (`0x12` full content or `0x13` partial content) to results of the previous step.
 4. Encode and return the resulting 9-byte sequence with [`encode`](#encode)
 
-See also: [Content-Code-Image reference code](https://github.com/iscc/iscc-specs/blob/master/src/iscc/iscc.py#L81)
+See also: [Content-Code-Image reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L81)
 
 !!! note "Image Data Input"
     The `content_id_image` function may optionally accept the raw byte data of an encoded image or an internal native image object as input for convenience.
@@ -259,7 +259,7 @@ Signature: `conent_id_mixed(cids: List[str], partial: bool=False) -> str`
 4. Prepend the 1-byte component header(`0x18` full content or `0x19` partial content)
 5. Apply [`encode`](#encode) to the result of step 5 and return the result.
 
-See also: [Content-Code-Mixed reference code](https://github.com/iscc/iscc-specs/blob/master/src/iscc/iscc.py#L102)
+See also: [Content-Code-Mixed reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L102)
 
 #### Partial Content Flag (PCF)
 
@@ -296,7 +296,7 @@ The Data-Code is built from the raw encoded data of the content to be identified
 7. Prepend the 1-byte component header (eg. 0x20).
 8. Apply [`encode`](#encode) to the result of step 6 and return the result.
 
-See also: [Data-Code reference code](https://github.com/iscc/iscc-specs/blob/master/src/iscc/iscc.py#L123)
+See also: [Data-Code reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L123)
 
 ### Instance-Code Component
 
@@ -320,7 +320,7 @@ An ISCC generating application MUST provide a `instance_id` function that accept
 8. Hex-Encode the tophash
 9. Return the Instance-Code and the hex-encoded tophash
 
-See also: [Instance-Code reference code](https://github.com/iscc/iscc-specs/blob/master/src/iscc/iscc.py#L144)
+See also: [Instance-Code reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L144)
 
 Applications may carry, store, and process the leaf node hashes for advanced streaming data identification or partial data integrity verification.
 
@@ -384,7 +384,7 @@ Applications MAY embed ISCC codes that have side effects if they specify a proce
 
 !!! example "ISCC Embedding"
 
-    We can embed the following combination of components from the [markdown version](https://github.com/iscc/iscc-specs/edit/master/docs/specification.md) of this document into the document itself because adding or removing them has no side effect:
+    We can embed the following combination of components from the [markdown version](https://github.com/iscc/iscc-codes/edit/version-1.1/docs/specification.md) of this document into the document itself because adding or removing them has no side effect:
 
     **ISCC**: CCDbMYw6NfC8a-CTtW9UFozcmBJ-CDYJsRdBNAERM
 
@@ -432,7 +432,7 @@ Signature: `encode(digest: bytes) -> str`
 
 The `encode` function accepts a 9-byte **ISCC Component Digest** and returns the Base58-ISCC encoded alphanumeric string of 13 characters, which we call the **ISCC-Component Code**.
 
-See also: [Base-ISCC Encoding reference code](https://github.com/iscc/iscc-specs/blob/master/src/iscc/iscc.py#L476)
+See also: [Base-ISCC Encoding reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L476)
 
 #### decode
 
@@ -440,7 +440,7 @@ Signature: decode(code: str) -> bytes
 
 the `decode` function accepts a 13-character **ISCC-Component Code** and returns the corresponding 9-byte **ISCC-Component Digest**.
 
-See also: [Base-ISCC Decoding reference code](https://github.com/iscc/iscc-specs/blob/master/src/iscc/iscc.py#L496)
+See also: [Base-ISCC Decoding reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L496)
 
 ### Content Normalization
 
@@ -452,7 +452,7 @@ Signature: `text_trim(text: str) -> str`
 
 Trim text such that its UTF-8 encoded byte representation does not exceed 128-bytes each. Remove leading and trailing whitespace.
 
-See also: [Text trimming reference code](https://github.com/iscc/iscc-specs/blob/master/src/iscc/iscc.py#L175)
+See also: [Text trimming reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L175)
 
 #### text_normalize
 
@@ -471,7 +471,7 @@ We define a text normalization function that is specific to our application. It 
 6. Keep or remove whitespace depending on the `keep_ws` parameter
 7. Re-Combine the text by applying `Unicode Normalization Form KC (NFKC)`.
 
-See also: [Text normalization reference code](https://github.com/iscc/iscc-specs/blob/master/src/iscc/iscc.py#L180)
+See also: [Text normalization reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L180)
 
 #### image_normalize
 
@@ -483,7 +483,7 @@ Accepts a file path, byte-stream or raw binary image data and MUST at least supp
 2. Resize the image to 32x32 pixels using [bicubic interpolation](https://en.wikipedia.org/wiki/Bicubic_interpolation)
 3. Create a 32x32 two-dimensional array of 8-bit gray-scale values from the image data
 
-See also: [Image normalization reference code](https://github.com/iscc/iscc-specs/blob/master/src/iscc/iscc.py#L217)
+See also: [Image normalization reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L217)
 
 ### Feature Hashing
 
@@ -497,7 +497,7 @@ The `similarity_hash` function takes a sequence of hash digests that represent a
 
 ![iscc-similarity-hash](images/iscc-similarity-hash.svg)
 
-See also: [Similarity hash reference code](https://github.com/iscc/iscc-specs/blob/master/src/iscc/iscc.py#L239)
+See also: [Similarity hash reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L239)
 
 #### minimum_hash
 
@@ -505,7 +505,7 @@ Signature: `minimum_hash(features: Iterable[int], n: int = 64) -> List[int]`
 
 The `minimum_hash` function takes an arbitrary-sized set of 32-bit integer features and reduces it to a fixed size vector of `n` features such that it preserves similarity with other sets. It is based on the MinHash implementation of the [datasketch](https://ekzhu.github.io/datasketch/) library by [Eric Zhu](https://github.com/ekzhu).
 
-See also: [Minimum hash reference code](https://github.com/iscc/iscc-specs/blob/master/src/iscc/iscc.py#L263)
+See also: [Minimum hash reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L263)
 
 #### image_hash
 
@@ -518,7 +518,7 @@ Signature: `image_hash(pixels: List[List[int]]) -> bytes`
 5. Create a 64-bit digest by iterating over the values of step 5 and setting a  `1`- for values above median and `0` for values below or equal to the median.
 6. Return results from step 5.
 
-See also: [Image hash reference code](https://github.com/iscc/iscc-specs/blob/master/src/iscc/iscc.py#L274)
+See also: [Image hash reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L274)
 
 ### Content Defined Chunking
 
@@ -530,11 +530,11 @@ Signature: `data_chunks(data: stream) -> Iterator[bytes]`
 
 The `data_chunks` function accepts a byte-stream and returns variable sized chunks. Chunk boundaries are determined by a gear based chunking algorithm based on [[WenXia2016]][#WenXia2016].
 
-See also: [CDC reference code](https://github.com/iscc/iscc-specs/blob/master/src/iscc/iscc.py#L334)
+See also: [CDC reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L334)
 
 ## Conformance Testing
 
-An application that claims ISCC conformance MUST pass all required functions from the ISCC conformance test suite. The test suite is available as JSON data in our [Github Repository](https://raw.githubusercontent.com/iscc/iscc-specs/master/tests/test_data.json). Test data is structured as follows:
+An application that claims ISCC conformance MUST pass all required functions from the ISCC conformance test suite. The test suite is available as JSON data in our [Github Repository](https://raw.githubusercontent.com/iscc/iscc-codes/master/tests/test_data.json). Test data is structured as follows:
 
 ```json
 {

--- a/maintainers/site-migration.md
+++ b/maintainers/site-migration.md
@@ -10,7 +10,7 @@ forward to the most relevant replacement.
 
 - Public site: <https://iscc.codes/>
 - Custom domain: `iscc.codes`
-- GitHub repository: `iscc/iscc-specs`
+- GitHub repository: `iscc/iscc-codes`
 - Documentation source branch for the current site: `version-1.1`
 - Published GitHub Pages branch: `gh-pages`
 - GitHub Pages source: `gh-pages` branch, repository root

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,12 +2,12 @@
 site_name: 'ISCC - Content Codes'
 site_description: 'International Standard Content Code - Specification'
 site_author: 'Titusz Pan'
-site_url: 'http://iscc.codes'
+site_url: 'https://iscc.codes'
 
 # Repository
-repo_name: 'iscc/iscc-specs'
-repo_url: 'https://github.com/iscc/iscc-specs'
-edit_uri: 'edit/master/docs/'
+repo_name: 'iscc/iscc-codes'
+repo_url: 'https://github.com/iscc/iscc-codes'
+edit_uri: 'edit/version-1.1/docs/'
 
 # Copyright
 copyright: 'Copyright © 2016-2022 The Authors
@@ -57,7 +57,7 @@ nav:
     - Resources: 'resources.md'
     - Versions:
           - Version 1.x: 'specification.md'
-          - Version 1.0: 'https://github.com/iscc/iscc-specs/blob/version-1.0/docs/specification.md'
+          - Version 1.0: 'https://github.com/iscc/iscc-codes/blob/version-1.0/docs/specification.md'
     - License: 'license.md'
 
 extra:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Titusz Pan <tp@py7.de>"]
 license="BSD 2-clause"
 readme = "README.md"
 homepage = "https://iscc.codes/"
-repository = "https://github.com/iscc/iscc-specs"
+repository = "https://github.com/iscc/iscc-codes"
 keywords=["iscc", "identifier", "media", "content", "hash", "blockchain", "similarity"]
 classifiers=[
     "Development Status :: 4 - Beta",

--- a/scripts/check_site_paths.py
+++ b/scripts/check_site_paths.py
@@ -26,6 +26,15 @@ REQUIRED_SOURCE_PATHS = {
 # Historical path currently handled by mkdocs-redirects.
 COMPATIBILITY_PATHS = ("/implementations/",)
 
+EXPECTED_MKDOCS_SETTINGS = {
+    "site_url": "https://iscc.codes",
+    "repo_name": "iscc/iscc-codes",
+    "repo_url": "https://github.com/iscc/iscc-codes",
+    "edit_uri": "edit/version-1.1/docs/",
+}
+
+OLD_REPOSITORY_SLUG = "iscc/iscc-specs"
+
 
 def generated_index_for(site_dir: Path, url_path: str) -> Path:
     """Return the expected generated index.html file for a canonical path."""
@@ -56,11 +65,31 @@ def check_source_files(repo_root: Path) -> list[str]:
     mkdocs_config = repo_root / "mkdocs.yml"
     if mkdocs_config.is_file():
         mkdocs_text = mkdocs_config.read_text(encoding="utf-8")
+        for key, expected_value in EXPECTED_MKDOCS_SETTINGS.items():
+            setting_pattern = re.compile(
+                rf"^{re.escape(key)}:\s*['\"]{re.escape(expected_value)}['\"]\s*$",
+                re.MULTILINE,
+            )
+            if setting_pattern.search(mkdocs_text) is None:
+                errors.append(f"mkdocs.yml should set {key}: {expected_value}")
+
         redirect_pattern = re.compile(
             r"['\"]?implementations\.md['\"]?\s*:\s*['\"]?resources\.md['\"]?"
         )
         if redirect_pattern.search(mkdocs_text) is None:
             errors.append("mkdocs.yml should preserve implementations.md -> resources.md redirect")
+
+    old_slug_files = (
+        repo_root / "README.md",
+        repo_root / "mkdocs.yml",
+        repo_root / "pyproject.toml",
+        repo_root / "docs/resources.md",
+        repo_root / "docs/specification.md",
+        repo_root / "maintainers/site-migration.md",
+    )
+    for path in old_slug_files:
+        if path.is_file() and OLD_REPOSITORY_SLUG in path.read_text(encoding="utf-8"):
+            errors.append(f"old repository slug remains in {path.relative_to(repo_root)}")
 
     return errors
 


### PR DESCRIPTION
## Summary

- Update repository metadata after the rename from `iscc/iscc-specs` to `iscc/iscc-codes`.
- Update README, MkDocs, package metadata, maintainer notes, and public documentation links to the new repository URL.
- Switch `iscc.codes` metadata links to HTTPS where touched.
- Extend the site compatibility checker so future changes keep the renamed repository metadata and avoid stale repository slugs.

## Notes

- This is intentionally limited to post-rename metadata/link cleanup.
- No content architecture, documentation framework, or legacy code retirement changes are included.
- Existing GitHub redirects from the old repository URL were verified before this PR.

## Test plan

- `python scripts/check_site_paths.py`
- `python -m py_compile scripts/check_site_paths.py`
- `git diff --check`
- Codex read-only blocker review: PASS