### PR TITLE
docs: clean up main branch references

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,7 +3,6 @@ name: Deploy documentation
 on:
   push:
     branches:
-      - master
       - main
     paths:
       - "docs/**"

--- a/.github/workflows/site-compatibility.yml
+++ b/.github/workflows/site-compatibility.yml
@@ -3,7 +3,6 @@ name: Site compatibility
 on:
   pull_request:
     branches:
-      - master
       - main
     paths:
       - "docs/**"

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -4,7 +4,7 @@ authors: Titusz Pan
 
 # ISCC - Resources
 
-If you find something that is missing from this collection of resources for the ISCC, [please add it](https://github.com/iscc/iscc-codes/edit/version-1.1/docs/resources.md).
+If you find something that is missing from this collection of resources for the ISCC, [please add it](https://github.com/iscc/iscc-codes/edit/main/docs/resources.md).
 
 ## ISCC - Official Software & Tools
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -172,7 +172,7 @@ An ISCC generating application must follow these steps in the given order to pro
 9. Return encoded Meta-Code, trimmed `title` and trimmed `extra` data.
 
 
-See also: [Meta-Code reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L19)
+See also: [Meta-Code reference code](https://github.com/iscc/iscc-codes/blob/main/src/iscc/iscc.py#L19)
 
 !!! warning "Text trimming"
     When trimming text be sure to trim the byte-length of the UTF-8 encoded version and not the number of characters. The trim point MUST be such that it does not cut into multi-byte characters. Characters might have different UTF-8 byte-length. For example `ü` is 2-bytes, `驩` is 3-bytes and `𠜎` is 4-bytes. So the trimmed version of a string with 128 `驩`-characters will result in a 42-character string with a 126-byte UTF-8 encoded length. This is necessary because the results of this operation will be stored as basic metadata with strict byte size limits on the blockchain.
@@ -226,7 +226,7 @@ An ISCC generating application MUST provide a `content_id(text, partial=False)` 
 7. Prepend the 1-byte component header (`0x10` full content or `0x11` partial content).
 8. Encode and return the resulting 9-byte sequence with [`encode`](#encode).
 
-See also: [Content-Code-Text reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L54)
+See also: [Content-Code-Text reference code](https://github.com/iscc/iscc-codes/blob/main/src/iscc/iscc.py#L54)
 
 #### Content-Code-Image
 
@@ -239,7 +239,7 @@ An ISCC generating application MUST provide a `content_id_image(image, partial=F
 3. Prepend the 1-byte component header (`0x12` full content or `0x13` partial content) to results of the previous step.
 4. Encode and return the resulting 9-byte sequence with [`encode`](#encode)
 
-See also: [Content-Code-Image reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L81)
+See also: [Content-Code-Image reference code](https://github.com/iscc/iscc-codes/blob/main/src/iscc/iscc.py#L81)
 
 !!! note "Image Data Input"
     The `content_id_image` function may optionally accept the raw byte data of an encoded image or an internal native image object as input for convenience.
@@ -259,7 +259,7 @@ Signature: `conent_id_mixed(cids: List[str], partial: bool=False) -> str`
 4. Prepend the 1-byte component header(`0x18` full content or `0x19` partial content)
 5. Apply [`encode`](#encode) to the result of step 5 and return the result.
 
-See also: [Content-Code-Mixed reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L102)
+See also: [Content-Code-Mixed reference code](https://github.com/iscc/iscc-codes/blob/main/src/iscc/iscc.py#L102)
 
 #### Partial Content Flag (PCF)
 
@@ -296,7 +296,7 @@ The Data-Code is built from the raw encoded data of the content to be identified
 7. Prepend the 1-byte component header (eg. 0x20).
 8. Apply [`encode`](#encode) to the result of step 6 and return the result.
 
-See also: [Data-Code reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L123)
+See also: [Data-Code reference code](https://github.com/iscc/iscc-codes/blob/main/src/iscc/iscc.py#L123)
 
 ### Instance-Code Component
 
@@ -320,7 +320,7 @@ An ISCC generating application MUST provide a `instance_id` function that accept
 8. Hex-Encode the tophash
 9. Return the Instance-Code and the hex-encoded tophash
 
-See also: [Instance-Code reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L144)
+See also: [Instance-Code reference code](https://github.com/iscc/iscc-codes/blob/main/src/iscc/iscc.py#L144)
 
 Applications may carry, store, and process the leaf node hashes for advanced streaming data identification or partial data integrity verification.
 
@@ -384,7 +384,7 @@ Applications MAY embed ISCC codes that have side effects if they specify a proce
 
 !!! example "ISCC Embedding"
 
-    We can embed the following combination of components from the [markdown version](https://github.com/iscc/iscc-codes/edit/version-1.1/docs/specification.md) of this document into the document itself because adding or removing them has no side effect:
+    We can embed the following combination of components from the [markdown version](https://github.com/iscc/iscc-codes/edit/main/docs/specification.md) of this document into the document itself because adding or removing them has no side effect:
 
     **ISCC**: CCDbMYw6NfC8a-CTtW9UFozcmBJ-CDYJsRdBNAERM
 
@@ -432,7 +432,7 @@ Signature: `encode(digest: bytes) -> str`
 
 The `encode` function accepts a 9-byte **ISCC Component Digest** and returns the Base58-ISCC encoded alphanumeric string of 13 characters, which we call the **ISCC-Component Code**.
 
-See also: [Base-ISCC Encoding reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L476)
+See also: [Base-ISCC Encoding reference code](https://github.com/iscc/iscc-codes/blob/main/src/iscc/iscc.py#L476)
 
 #### decode
 
@@ -440,7 +440,7 @@ Signature: decode(code: str) -> bytes
 
 the `decode` function accepts a 13-character **ISCC-Component Code** and returns the corresponding 9-byte **ISCC-Component Digest**.
 
-See also: [Base-ISCC Decoding reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L496)
+See also: [Base-ISCC Decoding reference code](https://github.com/iscc/iscc-codes/blob/main/src/iscc/iscc.py#L496)
 
 ### Content Normalization
 
@@ -452,7 +452,7 @@ Signature: `text_trim(text: str) -> str`
 
 Trim text such that its UTF-8 encoded byte representation does not exceed 128-bytes each. Remove leading and trailing whitespace.
 
-See also: [Text trimming reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L175)
+See also: [Text trimming reference code](https://github.com/iscc/iscc-codes/blob/main/src/iscc/iscc.py#L175)
 
 #### text_normalize
 
@@ -471,7 +471,7 @@ We define a text normalization function that is specific to our application. It 
 6. Keep or remove whitespace depending on the `keep_ws` parameter
 7. Re-Combine the text by applying `Unicode Normalization Form KC (NFKC)`.
 
-See also: [Text normalization reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L180)
+See also: [Text normalization reference code](https://github.com/iscc/iscc-codes/blob/main/src/iscc/iscc.py#L180)
 
 #### image_normalize
 
@@ -483,7 +483,7 @@ Accepts a file path, byte-stream or raw binary image data and MUST at least supp
 2. Resize the image to 32x32 pixels using [bicubic interpolation](https://en.wikipedia.org/wiki/Bicubic_interpolation)
 3. Create a 32x32 two-dimensional array of 8-bit gray-scale values from the image data
 
-See also: [Image normalization reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L217)
+See also: [Image normalization reference code](https://github.com/iscc/iscc-codes/blob/main/src/iscc/iscc.py#L217)
 
 ### Feature Hashing
 
@@ -497,7 +497,7 @@ The `similarity_hash` function takes a sequence of hash digests that represent a
 
 ![iscc-similarity-hash](images/iscc-similarity-hash.svg)
 
-See also: [Similarity hash reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L239)
+See also: [Similarity hash reference code](https://github.com/iscc/iscc-codes/blob/main/src/iscc/iscc.py#L239)
 
 #### minimum_hash
 
@@ -505,7 +505,7 @@ Signature: `minimum_hash(features: Iterable[int], n: int = 64) -> List[int]`
 
 The `minimum_hash` function takes an arbitrary-sized set of 32-bit integer features and reduces it to a fixed size vector of `n` features such that it preserves similarity with other sets. It is based on the MinHash implementation of the [datasketch](https://ekzhu.github.io/datasketch/) library by [Eric Zhu](https://github.com/ekzhu).
 
-See also: [Minimum hash reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L263)
+See also: [Minimum hash reference code](https://github.com/iscc/iscc-codes/blob/main/src/iscc/iscc.py#L263)
 
 #### image_hash
 
@@ -518,7 +518,7 @@ Signature: `image_hash(pixels: List[List[int]]) -> bytes`
 5. Create a 64-bit digest by iterating over the values of step 5 and setting a  `1`- for values above median and `0` for values below or equal to the median.
 6. Return results from step 5.
 
-See also: [Image hash reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L274)
+See also: [Image hash reference code](https://github.com/iscc/iscc-codes/blob/main/src/iscc/iscc.py#L274)
 
 ### Content Defined Chunking
 
@@ -530,11 +530,11 @@ Signature: `data_chunks(data: stream) -> Iterator[bytes]`
 
 The `data_chunks` function accepts a byte-stream and returns variable sized chunks. Chunk boundaries are determined by a gear based chunking algorithm based on [WenXia2016][WenXia2016].
 
-See also: [CDC reference code](https://github.com/iscc/iscc-codes/blob/master/src/iscc/iscc.py#L334)
+See also: [CDC reference code](https://github.com/iscc/iscc-codes/blob/main/src/iscc/iscc.py#L334)
 
 ## Conformance Testing
 
-An application that claims ISCC conformance MUST pass all required functions from the ISCC conformance test suite. The test suite is available as JSON data in our [Github Repository](https://raw.githubusercontent.com/iscc/iscc-codes/master/tests/test_data.json). Test data is structured as follows:
+An application that claims ISCC conformance MUST pass all required functions from the ISCC conformance test suite. The test suite is available as JSON data in our [Github Repository](https://raw.githubusercontent.com/iscc/iscc-codes/main/tests/test_data.json). Test data is structured as follows:
 
 ```json
 {

--- a/maintainers/site-migration.md
+++ b/maintainers/site-migration.md
@@ -11,7 +11,7 @@ forward to the most relevant replacement.
 - Public site: <https://iscc.codes/>
 - Custom domain: `iscc.codes`
 - GitHub repository: `iscc/iscc-codes`
-- Documentation source branch for the current site: `version-1.1`
+- Documentation source branch for the current site: `main`
 - Published GitHub Pages branch: `gh-pages`
 - GitHub Pages source: `gh-pages` branch, repository root
 - Custom domain file: `docs/CNAME` in the source branch and `CNAME` in the

--- a/scripts/check_site_paths.py
+++ b/scripts/check_site_paths.py
@@ -30,7 +30,7 @@ EXPECTED_SITE_SETTINGS = {
     "site_url": "https://iscc.codes",
     "repo_name": "iscc/iscc-codes",
     "repo_url": "https://github.com/iscc/iscc-codes",
-    "edit_uri": "edit/version-1.1/docs/",
+    "edit_uri": "edit/main/docs/",
 }
 
 OLD_REPOSITORY_SLUG = "iscc/iscc-specs"

--- a/zensical.toml
+++ b/zensical.toml
@@ -5,7 +5,7 @@ site_author = "Titusz Pan"
 site_url = "https://iscc.codes"
 repo_url = "https://github.com/iscc/iscc-codes"
 repo_name = "iscc/iscc-codes"
-edit_uri = "edit/version-1.1/docs/"
+edit_uri = "edit/main/docs/"
 copyright = "Copyright &copy; 2016-2026 The Authors | <a href=\"https://iscc.foundation/privacy\">Privacy Policy</a> | <a href=\"https://iscc.foundation/cookies\">Cookie Policy</a> | <a href=\"https://iscc.foundation/imprint\">Imprint</a> | <a href=\"https://iscc.foundation/disclaimer\">Disclaimer</a>"
 extra_css = ["stylesheets/custom.css"]
 


### PR DESCRIPTION
## Summary
- Point Zensical edit links and compatibility checks at `main` after the default branch rename.
- Update published docs links that still referenced `version-1.1` or `master` for this repository.
- Remove obsolete `master` triggers from documentation workflows.
- Update maintainer migration notes to record `main` as the current docs source branch.

## Verification
- `python scripts/check_site_paths.py`
- `uvx --from zensical==0.0.43 zensical build --clean`
- `python scripts/check_site_paths.py --site-dir site`
- GitHub commit API reports this commit signature as verified.