### PR TITLE
docs: refresh stale ISCC content

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 [![Downloads](https://pepy.tech/badge/iscc)](https://pepy.tech/project/iscc)
 [![DOI](https://zenodo.org/badge/96668860.svg)](https://zenodo.org/badge/latestdoi/96668860)
 
-| WARNING: The code and specs in this repository are an **out of date** early draft and retained for historic reasons only. For the current reference implementation see: [iscc-core](https://github.com/iscc/iscc-core). For status of specs see: [ISO/DIS 24138](https://www.iso.org/standard/77899.html). |
+| WARNING: The code and specs in this repository are an **out of date** early draft and retained for historic reasons only. For the current reference implementation see: [iscc-core](https://github.com/iscc/iscc-core). For the standardized specification see: [ISO 24138:2024](https://www.iso.org/standard/77899.html). For a high-level Python toolkit see: [iscc-sdk](https://github.com/iscc/iscc-sdk). |
 | --- |
 
-The **International Standard Content Code** is a proposal for an [open standard](https://en.wikipedia.org/wiki/Open_standard) for decentralized content identification. This repository contains the specification of the proposed **ISCC Standard** and a reference implementation in Python3. The latest published version of the specification can be found at [iscc.codes](https://iscc.codes)
+The **International Standard Content Code** is an [open standard](https://en.wikipedia.org/wiki/Open_standard) for content-derived digital media identification. This repository now contains the `iscc.codes` documentation site, historical specification material, and an outdated Python proof-of-concept implementation retained for continuity. The current Python reference implementation lives in [iscc-core](https://github.com/iscc/iscc-core); higher-level media processing is provided by [iscc-sdk](https://github.com/iscc/iscc-sdk).
 
-## Installing the reference code
+## Installing the legacy proof-of-concept code
 
-The reference code is published with the package name [iscc](https://pypi.org/project/iscc/#history) on Python Package Index. Install the latest beta release with:
+The historical proof-of-concept code was published with the package name [iscc](https://pypi.org/project/iscc/#history) on the Python Package Index. It is retained for compatibility only and is not recommended for new integrations. New Python projects should use [iscc-core](https://pypi.org/project/iscc-core/) or [iscc-sdk](https://pypi.org/project/iscc-sdk/). If you need the legacy package, install a pinned release with:
 
 ``` bash
 pip install iscc==1.1.0b17
@@ -32,9 +32,9 @@ from iscc.bin import install
 install()
 ```
 
-## Using the reference code
+## Using the legacy proof-of-concept code
 
-A short example on how to create an ISCC Code with the reference implementation.
+A short historical example on how to create an ISCC Code with the legacy implementation.
 
 ``` python
 >>> import iscc
@@ -66,7 +66,7 @@ A short example on how to create an ISCC Code with the reference implementation.
 
 ## Working with the specification
 
-| NOTE: This is ISCC Version 1.1 - The specs are not yet updated!!! |
+| NOTE: This repository currently carries historical ISCC Version 1.1 material. Current implementation guidance lives in `iscc-core` and `iscc-sdk`. |
 | --- |
 
 The entire **ISCC Specification** is written in plain text [Markdown](https://en.wikipedia.org/wiki/Markdown). The Markdown content is built and published with [Zensical](https://zensical.org/). If you have basic command line skills you can build and run the specification site on your own computer. Make sure you have [git](https://git-scm.com/) and [Python](https://www.python.org/) installed on your system and follow these steps on the command line:

--- a/docs/concept.md
+++ b/docs/concept.md
@@ -1,8 +1,11 @@
 # ISCC - Concept
 
+!!! note "Historical context"
+    This page preserves early design rationale for the ISCC. Some proof-of-concept and blockchain-specific statements predate the ISO 24138:2024 standardization work and the current `iscc-core` / `iscc-sdk` implementations.
+
 *The internet is shifting towards a network of decentralized peer-to-peer transactions. If we want our transactions on the emerging blockchain networks to be about content we need standardized ways to address content. Our transactions might be payments, attributions, reputation, certification, licenses or entirely new kinds of value transfer. All this will happen much faster and easier if we, as a community, can agree on how to identify content in a decentralized environment.*
 
-This is the higher level concept of an open proposal to the wider content community for a common content identifier. We would like to share our ideas and spark a conversation with journalists, news agencies, content creators, publishers, distributors, libraries, musicians, scientists, developers, lawyers, rights organizations and all the other participants of the content ecosystem.
+This page started as the higher level concept of an open proposal to the wider content community for a common content identifier. We would like to share our ideas and spark a conversation with journalists, news agencies, content creators, publishers, distributors, libraries, musicians, scientists, developers, lawyers, rights organizations and all the other participants of the content ecosystem.
 
 ## Introduction
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,12 +21,17 @@ authors: Titusz Pan
 - https://demo.iscc.io
 - https://huggingface.co/spaces/iscc/iscc-playground
 
+## Developer entry points
+
+- [iscc-core](https://github.com/iscc/iscc-core) — current Python reference implementation of the ISO 24138 core algorithms
+- [iscc-sdk](https://github.com/iscc/iscc-sdk) — high-level Python toolkit for generating ISCCs from media files
+
 
 !!! note "ISCC Standard - ISO 24138"
     ### Latest status of standardization:
     [ISO 24138 - Information and documentation - International Standard Content Code (ISCC)](https://www.iso.org/standard/77899.html)
-    ### Official reference implementation:
-    [ISCC - Codec & Algorithms](https://core.iscc.codes)
+    ### Current implementation guidance:
+    [ISCC - Codec & Algorithms](https://core.iscc.codes) and [ISCC Software Development Kit](https://sdk.iscc.codes)
 
 
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -8,17 +8,21 @@ If you find something that is missing from this collection of resources for the 
 
 ## ISCC - Official Software & Tools
 
-### [ISCC - CLI](https://github.com/iscc/iscc-cli)
+### [iscc-core](https://github.com/iscc/iscc-core)
 
-An open-source command-line tool that can be used on **Windows**, **Linux**, and **Mac** systems by developers and computer savvy persons to create ISCC codes from media files and URLs. The tool is based on the [reference implementation](https://github.com/iscc/iscc-codes) but also includes **new and experimental features** (e.g., Audio-Codes, Video-Codes) that are not yet part of the [public specification](https://iscc.codes/specification/).
+Current Python reference implementation of the ISCC core algorithms defined by [ISO 24138:2024](https://www.iso.org/standard/77899.html). Install from PyPI with `pip install iscc-core`. Documentation: <https://core.iscc.codes/>.
 
-### [ISCC - Web Service](https://github.com/iscc/iscc-service)
+### [iscc-sdk](https://github.com/iscc/iscc-sdk)
 
-A REST OpenAPI backend service application for creating [**ISCC codes**](https://iscc.codes/) for digital media files and URLs. The Webservice is built with [FastAPI](https://github.com/tiangolo/fastapi) and makes use of the [ISCC reference implementation](https://github.com/iscc/iscc-codes) and the [ISCC Command Line Tool](https://github.com/iscc/iscc-cli) and includes interactive API documentation.
+High-level Python toolkit for creating and managing ISCCs from media files. It builds on `iscc-core` and adds media type detection, metadata handling, content extraction, and a command-line interface. Install from PyPI with `pip install iscc-sdk`. Documentation: <https://sdk.iscc.codes/>.
 
-### [ISCC - Specification & Reference Implementation](https://github.com/iscc/iscc-codes)
+### [ISCC Web Demo](https://demo.iscc.io/)
 
-The official ISCC reference implementation. The reference code is published on the [Python Package Index](https://pypi.org/project/iscc/) and can be installed as a library by developers. The ISCC specification is written in markdown and hosted in the same [source code repository](https://github.com/iscc/iscc-codes) and published at [https://iscc.codes/specification](https://iscc.codes/specification/). For contributions and public discussions, please use the corresponding [issue tracker](https://github.com/iscc/iscc-codes/issues).
+Minimal web application for generating ISCCs in the browser. Source code: [iscc-web](https://github.com/iscc/iscc-web).
+
+### [ISCC Codes](https://github.com/iscc/iscc-codes)
+
+Source repository for this `iscc.codes` documentation site and historical ISCC Version 1.1 specification material. The legacy Python package [`iscc`](https://pypi.org/project/iscc/) is an outdated proof-of-concept retained for compatibility; new integrations should use `iscc-core` or `iscc-sdk`.
 
 ## ISCC - Third-Party Implementations
 
@@ -75,4 +79,4 @@ In particular, the foundation supports the **ISCC** and promotes the development
 
 ### [ISO - International Organization for Standardization](https://www.iso.org/committee/48836.html)
 
-**ISO/TC 46/SC 9** (Identification and description) has accepted the **International Standard Content Code** as a preliminary work item and created a new working group (WG 18 - Digital-Content-Based Identification).
+**ISO/TC 46/SC 9** (Identification and description) standardized the **International Standard Content Code** as [ISO 24138:2024](https://www.iso.org/standard/77899.html).

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -8,7 +8,7 @@ authors: Titusz Pan
 
 !!! warning
 
-    This document is an **out of date** early draft and retained for historic reasons only. Please follow **current development** at https://ieps.iscc.codes
+    This document is an **out of date** early draft and retained for historic reasons only. For current implementation guidance see [iscc-core](https://github.com/iscc/iscc-core) and [iscc-sdk](https://github.com/iscc/iscc-sdk). For the standardized specification see [ISO 24138:2024](https://www.iso.org/standard/77899.html).
 
 ## Abstract
 
@@ -28,7 +28,7 @@ Public review, discussion and contributions are welcome.
 
 !!! note "Document Version"
 
-    While there is already a [Version 1.0](https://github.com/iscc/iscc-codes/blob/version-1.0/docs/specification.md) spec, we are still expecting backward incompatible changes until **Version 2.0**. Parts of this specification may become stable earlier. We will document this during minor releases. We encourage partners to follow development and test, implement, and give feedback based on the latest (this) version of the ISCC Specification.
+    This page preserves the historical ISCC Version 1.1 specification material for URL continuity and reference. For current implementation guidance see [iscc-core](https://github.com/iscc/iscc-core) and [iscc-sdk](https://github.com/iscc/iscc-sdk). For the standardized specification see [ISO 24138:2024](https://www.iso.org/standard/77899.html).
 
 This document proposes an open and vendor neutral ISCC standard and describes the technical procedures to create and manage ISCC identifiers. The first version of this document resulted from a prototyping project by the [Content Blockchain Project](https://content-blockchain.org) and received funding from the [Google Digital News Initiative (DNI)](https://digitalnewsinitiative.com/dni-projects/content-blockchain-project/). The content of this document results from a voluntary effort of the authors with an open and public consensus process.
 


### PR DESCRIPTION
## Summary
- Refresh stale ISCC status wording now that ISO 24138:2024 is published
- Point developers to current implementation sources: `iscc-core` and `iscc-sdk`
- Mark historical v1.1 specification/concept material as retained for URL continuity
- Replace outdated CLI/service/resource references with current official tools and demo links

## Verification
- `uvx --from zensical==0.0.43 zensical build`
- `python scripts/check_site_paths.py --repo-root . --site-dir site`
- `git diff --check`

## Notes
This is intentionally a minimal stale-content cleanup PR. The visual Zensical customization pass to match `iscc-usearch` more closely (icons in nav, blue header bar, etc.) should remain a separate PR.