### PR TITLE
docs: polish copy and ISCC code terminology

### DIFF
--- a/docs/concept.md
+++ b/docs/concept.md
@@ -10,7 +10,7 @@ icon: lucide/lightbulb
 
 *The internet is shifting towards a network of decentralized peer-to-peer transactions. If we want our transactions on the emerging blockchain networks to be about content we need standardized ways to address content. Our transactions might be payments, attributions, reputation, certification, licenses or entirely new kinds of value transfer. All this will happen much faster and easier if we, as a community, can agree on how to identify content in a decentralized environment.*
 
-This page started as the higher level concept of an open proposal to the wider content community for a common content identifier. We would like to share our ideas and spark a conversation with journalists, news agencies, content creators, publishers, distributors, libraries, musicians, scientists, developers, lawyers, rights organizations and all the other participants of the content ecosystem.
+This page started as the higher level concept of an open proposal to the wider content community for a common content identification code. We would like to share our ideas and spark a conversation with journalists, news agencies, content creators, publishers, distributors, libraries, musicians, scientists, developers, lawyers, rights organizations and all the other participants of the content ecosystem.
 
 ## Introduction
 
@@ -18,35 +18,35 @@ The **structure and management** of **global identifiers** strongly correlates w
 
 There are many [existing standards](https://xkcd.com/927/) for media identifiers serving a wide array of use cases. Book publishing uses the [**ISBN**](https://www.isbn-international.org/), magazines and journals have the [**ISSN**](https://www.issn.org/), music industry has [**ISRC**](https://isrc.ifpi.org/) and [**ISWC**](http://www.iswc.org/) and film has [**ISAN**](http://www.isan.org/) and [**EIDR**](https://eidr.org/) – each of them serving a set of specific purposes. On the other side of the spectrum there are also generic identifiers standards such as the [**DOI**](https://www.doi.org/), [**ITU HANDLE**](http://www.itu.int/osg/csd/emerging_trends/handle_system/index.html), [**URN**](https://tools.ietf.org/html/rfc8141), [**ARK**](https://tools.ietf.org/html/draft-kunze-ark-18). The DOI, for example, can be used to identify any digital, physical or abstract *object*. All these identifiers have important and distinct roles across different industries and use cases.
 
-The most substantial differentiator of the **ISCC** is the fact that it is **algorithmically bound to the digital content** it identifies. Other standards require human intervention to assign and track the mapping between identifier and object (binding). Many of those standards focus on how to resolve an identifier to some network location where metadata or the object itself can be found. The **ISCC inverts this principle**. It gives an answer to the question: "Given some digital content, how can I find its identifier to reference the content in a transaction?". This means that the **ISCC** for any digital content can be *found* (generated) from the content itself, without the need to involve any third-party.
+The most substantial differentiator of the **ISCC** is the fact that it is **algorithmically bound to the digital content** it identifies. Other standards require human intervention to assign and track the mapping between identifier and object (binding). Many of those standards focus on how to resolve a code to some network location where metadata or the object itself can be found. The **ISCC inverts this principle**. It gives an answer to the question: "Given some digital content, how can I find its code to reference the content in a transaction?". This means that the **ISCC** for any digital content can be *found* (generated) from the content itself, without the need to involve any third-party.
 
 As such the **ISCC** fulfills a distinct role and is **not a replacement for established identifiers**. Rather it is designed as an umbrella standard to augment established identifiers with enhanced algorithmic features. It can be used in the metadata of existing standards or support discoverability (reverse lookup).
 
-Many of the established systems are based on centralized or hierarchical registries that involve manual and costly management processes. To sustain such systems the costs have to be recouped by fees for identifier assignment, metadata storage or paid access to metadata which inhibits accessibility and discoverability. The overhead, cost and general properties of these systems make them prohibitive for many innovative use cases that require a more informal and generic identifier assignment (eg. granular content). Communities with short lived or user generated content, don't have any agreed-upon global identifiers for their content.
+Many of the established systems are based on centralized or hierarchical registries that involve manual and costly management processes. To sustain such systems the costs have to be recouped by fees for code assignment, metadata storage or paid access to metadata which inhibits accessibility and discoverability. The overhead, cost and general properties of these systems make them prohibitive for many innovative use cases that require a more informal and generic code assignment (eg. granular content). Communities with short lived or user generated content, don't have any agreed-upon global identifiers for their content.
 
 The fast paced development of the digital media economy has led to an increasing fragmentation of identifiers and new barriers in interoperability. For example major e-book retailers do not require an **ISBN** and instead established their own proprietary identifiers. Amazon has the **ASIN**, Apple has **Apple-ID** and Google has **GKEY**. For many tasks current systems need to track and match all the different vendor specific IDs, which is an inefficient and error prone process.
 
-Resolving an **ISCC** to a network location, metadata or the content itself can be accomplished with neutral and decentralized blockchain-based registries that don't require a centralized or hierarchical system to manage, track and store unique identifiers, ownership assignments, associated metadata and other information.
+Resolving an **ISCC** to a network location, metadata or the content itself can be accomplished with neutral and decentralized blockchain-based registries that don't require a centralized or hierarchical system to manage, track and store unique codes, ownership assignments, associated metadata and other information.
 
 Advances in data structures, algorithms, machine learning and the emergence of crypto economics allows us to invent **new** kinds of **media identifiers** and **re-imagine existing identifiers** with innovative use cases in mind. Blockchains and Smart Contracts offer great opportunities in solving many of the challenges of identifier registration, like centralized management, data duplication and disambiguation, vendor lock-in and long term data retention.
 
-This is an open proposal to the digital media community and explores the possibilities of a **decentralized **content identifier system. We’d like to establish an open standard for persistent, unique, vendor independent and content derived cross-media identifiers that can be stored and managed on global, public and decentralized blockchains. We envision a self-governing ecosystem with a low barrier of entry where **commercial and non-commercial** initiatives can both innovate and thrive next to each other.
+This is an open proposal to the digital media community and explores the possibilities of a **decentralized **content identification system. We’d like to establish an open standard for persistent, unique, vendor independent and content-derived cross-media codes that can be stored and managed on global, public and decentralized blockchains. We envision a self-governing ecosystem with a low barrier of entry where **commercial and non-commercial** initiatives can both innovate and thrive next to each other.
 
-## Media Identifiers for Blockchains
+## Media Identification Codes for Blockchains
 
 Media cataloging systems tend to get out of hand and become complex and often unmanageable. Our design proposal is focused on keeping the ISCC system as simple and more importantly as **automatable** as possible, while maximizing practical value for the most important use cases — meaning you should get out more than you have to put in. With this in mind we come to the following basic design decisions:
 
-### A “Meaningful” Identifier
+### A “Meaningful” Code
 
-In traditional database systems it is recommended practice to work with **surrogate keys** as identifiers. A surrogate key is a dumb number and has no business meaning and is completely decoupled from the data it identifies. Uniqueness of such identifiers is guaranteed either via centralized incremental assignment by the database system or via random UUIDs which have a very low probability of collisions. While random UUIDs could be generated in a decentralized way, both approaches require some external authority that establishes or certifies the linkage between the identifier and the associated metadata and content. This is why we decided to go with a “meaningful” **content and metadata derived identifier (CMDI)**. Anyone will be able to verify that a specific identifier indeed belongs to a given digital content. Even better, anyone can “find” the identifier for a given content without the need to consult external data sources. This approach also captures essential information about the media in the identifier itself, which is very useful in scenarios of machine learning and data analytics.
+In traditional database systems it is recommended practice to work with **surrogate keys** as identifiers. A surrogate key is a dumb number and has no business meaning and is completely decoupled from the data it identifies. Uniqueness of such identifiers is guaranteed either via centralized incremental assignment by the database system or via random UUIDs which have a very low probability of collisions. While random UUIDs could be generated in a decentralized way, both approaches require some external authority that establishes or certifies the linkage between the identifier and the associated metadata and content. This is why we decided to go with a “meaningful” **content and metadata derived code (CMDC)**. Anyone will be able to verify that a specific code indeed belongs to a given digital content. Even better, anyone can “find” the code for a given content without the need to consult external data sources. This approach also captures essential information about the media in the code itself, which is very useful in scenarios of machine learning and data analytics.
 
-### A Decentralized Identifier
+### A Decentralized Code
 
-The **ISCC** is designed to be registry agnostic. This means that content identification codes can be self-issued in a decentralized and parallel fashion without the need for governance by a centralized registration agency. Without registration an **ISCC** is owned by the content and not by a person or organization. An *unregistered* **ISCC** is useful in cases where multiple independent parties exchange information about content. The **CMDI** approach is helpful with common issues like data integrity, validation, de-duplication and disambiguation. Systems that process digital content can integrate ISCC support and benefit immediately. The integrator does not depend on all third-parties having to assign, track and deliver ISCC codes, because those can be generated from the content itself.
+The **ISCC** is designed to be registry agnostic. This means that content identification codes can be self-issued in a decentralized and parallel fashion without the need for governance by a centralized registration agency. Without registration an **ISCC** is owned by the content and not by a person or organization. An *unregistered* **ISCC** is useful in cases where multiple independent parties exchange information about content. The **CMDC** approach is helpful with common issues like data integrity, validation, de-duplication and disambiguation. Systems that process digital content can integrate ISCC support and benefit immediately. The integrator does not depend on all third-parties having to assign, track and deliver ISCC codes, because those can be generated from the content itself.
 
 ISCC registration becomes **necessary** when an ISCC code needs to be **globally unique, publicly discoverable, resolvable, owned** or **authenticated**. While these features inevitably require some kind of registry, not all of them require a centralized institutional registry.
 
-In a centralized system the central authority is in control of the issuance of identifiers and safeguards various requirements like identifier uniqueness or ownership. In a decentralized system where everybody can register an identifier we need a different approach.
+In a centralized system the central authority is in control of the issuance of codes and safeguards various requirements like code uniqueness or ownership. In a decentralized system where everybody can register a code we need a different approach.
 
 The **ISCC** will specify the necessary protocols to implement the aforementioned features in a decentralized, federated environment and across multiple public blockchains.  **Given a registered ISCC code, an application can unambiguously determine on what blockchain (if any), by which account, and at what time an ISCC has been registered. **
 
@@ -62,7 +62,7 @@ This approach retains global clustering and de-duplication features while at the
 
 ### Registration Services
 
-Registration services offer a plethora of valuable and indispensable benefits. Every industry has its special requirements. Ultimately the stakeholders from those industries will have to set the rules for data curation, metadata management and administrative control. A Blockchain is a low level backend infrastructure. And while blockchains might make access to identifiers and metadata more accessible, there is still cost involved with storing data, running the infrastructure and providing middleware and frontends. Blockchains work as incentive based economic systems. Registrars can offer **commercially viable** value added services on top of the lower level blockchain networks. For example:
+Registration services offer a plethora of valuable and indispensable benefits. Every industry has its special requirements. Ultimately the stakeholders from those industries will have to set the rules for data curation, metadata management and administrative control. A Blockchain is a low level backend infrastructure. And while blockchains might make access to codes and metadata more accessible, there is still cost involved with storing data, running the infrastructure and providing middleware and frontends. Blockchains work as incentive based economic systems. Registrars can offer **commercially viable** value added services on top of the lower level blockchain networks. For example:
 
 - Identity verification of registrants
 - Certification/attestation of registry entries
@@ -75,7 +75,7 @@ Registration services offer a plethora of valuable and indispensable benefits. E
 
 ### Storage Considerations
 
-On a typical public blockchain all data is **fully replicated** among participants. This allows for independent and autonomous validation of transactions. All blockchain data is highly available, immutable, tamper-proof, timestamped and in most cases openly accessible. However, under high load the limited transaction capacity (storage space per unit of time) creates a transaction fee market for on-chain data. This leads to **growing transaction costs** and makes storage a scarce and increasingly precious resource on public decentralized blockchains. For example  storing a 46 character identifier on the Ethereum blockchain in July 2019 cost ~ $0.50. So it is mandatory for our identifier and its eventual metadata schema to be very **space efficient **to maximize benefit at minimal cost. The basic metadata that will be required to generate and register identifiers must be:
+On a typical public blockchain all data is **fully replicated** among participants. This allows for independent and autonomous validation of transactions. All blockchain data is highly available, immutable, tamper-proof, timestamped and in most cases openly accessible. However, under high load the limited transaction capacity (storage space per unit of time) creates a transaction fee market for on-chain data. This leads to **growing transaction costs** and makes storage a scarce and increasingly precious resource on public decentralized blockchains. For example  storing a 46 character code on the Ethereum blockchain in July 2019 cost ~ $0.50. So it is mandatory for our code and its eventual metadata schema to be very **space efficient **to maximize benefit at minimal cost. The basic metadata that will be required to generate and register codes must be:
 
 - minimal in scope
 - clearly specified
@@ -85,7 +85,7 @@ On a typical public blockchain all data is **fully replicated** among participan
 
 ## Layers of Digital Media Identification
 
-While we examined existing identifiers we discovered that there is often much confusion about the extent or coverage of what exactly is being identified by a given system. With our idea for a generic cross-media identifier we want to put special weight on being precise with our definitions and found it helpful to distinguish between “different layers of digital media identification". We found that these layers exist naturally on a scale from abstract to concrete. Our analysis also showed that existing standard identifiers operate on one or at most two of such layers. The ISCC is designed as a **composite identifier** that takes the different layers of media identification into consideration:
+While we examined existing identifiers we discovered that there is often much confusion about the extent or coverage of what exactly is being identified by a given system. With our idea for a generic cross-media code we want to put special weight on being precise with our definitions and found it helpful to distinguish between “different layers of digital media identification". We found that these layers exist naturally on a scale from abstract to concrete. Our analysis also showed that existing standard identifiers operate on one or at most two of such layers. The ISCC is designed as a **composite content code** that takes the different layers of media identification into consideration:
 
 ### Layer 1 – Abstract Creation
 
@@ -97,17 +97,17 @@ This layer relates to the meaning or essence of a work. It is an amorphous colle
 
 ### Layer 3 – Generic Manifestation
 
-In this layer we are concerned with the literal structure of a media type specific and normalized manifestation. Namely the basic text, image, audio or video content independent of its semantic meaning or media file encoding and with a tolerance to variation. This "tolerance to variation" bundles a set of different versions with corrections, revisions, edits, updates, personalization, different format encodings or data compression of the same content under one grouping identifier. A generic manifestation is independent of a final digital media product and is specific to an expression, version or interpretation of a work.
+In this layer we are concerned with the literal structure of a media type specific and normalized manifestation. Namely the basic text, image, audio or video content independent of its semantic meaning or media file encoding and with a tolerance to variation. This "tolerance to variation" bundles a set of different versions with corrections, revisions, edits, updates, personalization, different format encodings or data compression of the same content under one grouping code. A generic manifestation is independent of a final digital media product and is specific to an expression, version or interpretation of a work.
 
-Unfortunately it is not obvious where generic manifestation of a work ends and another one starts. It depends on human interpretation and context. How much editing do we allow before we call it a “different” manifestation and give it a different identifier. A practical but only partial solution to this problem is to create an algorithmically defined and testable spectrum of tolerance to variation per media type. This can provide a stable and repeatable process to distinguish between generic content manifestations. But it is important to understand that such a process is not expected to yield results that are always intuitive to human expectations as to where exactly boundaries should be.
+Unfortunately it is not obvious where generic manifestation of a work ends and another one starts. It depends on human interpretation and context. How much editing do we allow before we call it a “different” manifestation and give it a different code. A practical but only partial solution to this problem is to create an algorithmically defined and testable spectrum of tolerance to variation per media type. This can provide a stable and repeatable process to distinguish between generic content manifestations. But it is important to understand that such a process is not expected to yield results that are always intuitive to human expectations as to where exactly boundaries should be.
 
 ### Layer 4 – Media Specific Manifestation
 
-This layer relates to a **manifestation with a specific encoding**. It identifies a **data-file** encoded and offered in a specific **media format **including a tolerance to variation to account for minor edits and updates within a format without creating a new identifier. For example, one could distinguish between the PDF, DOCX or WEBSITE versions of the same content as generated from a single source publishing system. This layer does only distinguish between products or "artifacts" with a given packaging or encoding.
+This layer relates to a **manifestation with a specific encoding**. It identifies a **data-file** encoded and offered in a specific **media format **including a tolerance to variation to account for minor edits and updates within a format without creating a new code. For example, one could distinguish between the PDF, DOCX or WEBSITE versions of the same content as generated from a single source publishing system. This layer does only distinguish between products or "artifacts" with a given packaging or encoding.
 
 ### Layer 5 – Exact Representation
 
-In this layer we identify a data-file by its exact binary representation without any interpretation of meaning and without any ambiguity. Even a minimal change in data that might not change the interpretation of content would create a different identifier. Like the first four layers, this layer does **not **express any information related to **content location** or **ownership**.
+In this layer we identify a data-file by its exact binary representation without any interpretation of meaning and without any ambiguity. Even a minimal change in data that might not change the interpretation of content would create a different code. Like the first four layers, this layer does **not **express any information related to **content location** or **ownership**.
 
 ### Layer 6 – Individual Copy
 
@@ -119,7 +119,7 @@ And most importantly such a replica does not affect the original data and even l
 
 ## Design Principles
 
-As a generic content identifier the **ISCC Standard** is a an initiative with a broad scope. These are the principles that should guide its design and adoption:
+As a generic content code the **ISCC Standard** is a an initiative with a broad scope. These are the principles that should guide its design and adoption:
 
 - Target existing, unsolved, real-world problems
 - Provide a technological and automatable solution
@@ -135,7 +135,7 @@ As a generic content identifier the **ISCC Standard** is a an initiative with a 
 
 ## Algorithmic Tools
 
-While many details about the ISCC are still up for discussion we are quite confident about some of the general algorithmic families that will make it into the final specification for the identifier. These will play an important role in how we generate the different components of the identifier:
+While many details about the ISCC are still up for discussion we are quite confident about some of the general algorithmic families that will make it into the final specification for the code. These will play an important role in how we generate the different components of the code:
 
 - Similarity preserving hash functions (Simhash, Minhash ...)
 - Perceptual hashing (pHash, Blockhash, Chromaprint …)
@@ -144,7 +144,7 @@ While many details about the ISCC are still up for discussion we are quite confi
 
 ## ISCC Proof-of-Concept
 
-Before we settle on the details of the proposed ISCC identifier, we built a simple and reduced proof-of-concept implementation of our ideas. It enables us and other developers to test with real world data and systems and find out early what works and what doesn't.
+Before we settle on the details of the proposed ISCC code, we built a simple and reduced proof-of-concept implementation of our ideas. It enables us and other developers to test with real world data and systems and find out early what works and what doesn't.
 
 ![img](images/iscc-web-demo.svg)
 
@@ -156,7 +156,7 @@ The minimal viable, first iteration ISCC will be a byte structure built from the
 
 ### Meta-Code
 
-The Meta-Code will be generated as a similarity preserving hash from minimal generic metadata like *title *and *creators*. It operates on **Layer 1 ** and identifies an intangible creation. It is the first and most generic grouping element of the identifier. We will be experimenting with different n-gram sizes and bit-length to find the practical limits of precision and recall for generic metadata. We will also specify a process to disambiguate unintended collisions by adding optional metadata.
+The Meta-Code will be generated as a similarity preserving hash from minimal generic metadata like *title *and *creators*. It operates on **Layer 1 ** and identifies an intangible creation. It is the first and most generic grouping element of the code. We will be experimenting with different n-gram sizes and bit-length to find the practical limits of precision and recall for generic metadata. We will also specify a process to disambiguate unintended collisions by adding optional metadata.
 
 ### Partial Content Flag
 
@@ -178,4 +178,4 @@ The Data-Code operates on **Layer 4 **and will be a similarity preserving hash g
 
 The Instance-Code operates on **Layer 5 **and will be the top hash of a Merkle tree generated from (potentially content-defined) chunks of raw data of an encoded media blob. It identifies a concrete manifestation and proves the integrity of the full content. We use the Merkle tree structure because it also allows as to verify integrity of partial chunks without having to have the full data available. This will be very useful in any scenarios of distributed data storage.
 
-We intentionally skip **Layer 6** at this stage as content ownership and location will be handled on the blockchain layer of the stack and not by the ISCC identifier itself.
+We intentionally skip **Layer 6** at this stage as content ownership and location will be handled on the blockchain layer of the stack and not by the ISCC code itself.

--- a/docs/features.md
+++ b/docs/features.md
@@ -11,7 +11,7 @@ icon: lucide/sparkles
 
 ## Granular Content Management
 
-The ISCC can be generated for any work as well as for parts, chunks or individual elements of the content. These elements could be an image, a table, a chapter or a quote within a given document. The relation between parent and child-elements can be  preserved in the ISCC identifier. Thus, it is possible to connect the various ID's, obtain their relations and identify the work from which any chunk is taken from. This feature can also help to identify plagiarism, in case chunks from one work have been used in a different work - only with access to the ISCC identifiers.
+The ISCC can be generated for any work as well as for parts, chunks or individual elements of the content. These elements could be an image, a table, a chapter or a quote within a given document. The relation between parent and child-elements can be preserved in the ISCC-CODE. Thus, it is possible to connect the various codes, obtain their relations and identify the work from which any chunk is taken from. This feature can also help to identify plagiarism, in case chunks from one work have been used in a different work - only with access to the ISCC-CODEs.
 
 [![ISCC Granular Content Identification](images/iscc-pcf.svg)](images/iscc-pcf.svg)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,19 +1,19 @@
 ---
-title: ISCC - International Standard Content Code - ISO 24138
-description: The intelligent digital media identifier.
+title: iscc-codes
+description: Modern and open content-based identification.
 authors: Titusz Pan
 icon: lucide/house
 ---
 
 # ISCC - International Standard Content Code
 
-## A Modern and Open Content-Based Identifier
+## Modern and open Content-Based Identification
 
 ![iscc-sample](images/iscc-algo-design.svg)
 
 ## The ISCC is...
 
-- a universal identifier for all types of digital content (text, image, audio, video)
+- a universal content code for all types of digital content (text, image, audio, video)
 - a lightweight and similarity-preserving fingerprint
 - designed for cross-sector applicability (journalism, books, music, film, etc.)
 - designed to identify content in decentralized and networked environments
@@ -42,20 +42,20 @@ icon: lucide/house
 
 Increasing amounts of dynamic, short-lived, and granular content need to be managed and require new and innovative tools.
 
-A crucial prerequisite for content-related transactions to succeed in this new and demanding environment is the capability to address and identify content efficiently. Yet many industries that deal with digital content do not even have standard identifiers. There is no existing solution for those industries that deal with short-lived or granular content such as journalism. There is also no widely adopted standardized identifier for digital images.
+A crucial prerequisite for content-related transactions to succeed in this new and demanding environment is the capability to address and identify content efficiently. Yet many industries that deal with digital content do not even have standard content codes. There is no existing solution for those industries that deal with short-lived or granular content such as journalism. There is also no widely adopted standardized content code for digital images.
 
-The overhead and cost of manually assigning and tracking identifiers for such content are prohibitive. But there is a solution to the problem: **auto-generated identifiers** created algorithmically from the content itself.
+The overhead and cost of manually assigning and tracking codes for such content are prohibitive. But there is a solution to the problem: **auto-generated content codes** created algorithmically from the content itself.
 
-In a multi-sided ecosystem, **anybody** may have a legitimate interest to generate, lookup, or register an identifier for some digital content – whether they own the content or not.
+In a multi-sided ecosystem, **anybody** may have a legitimate interest to generate, look up, or register a content code for some digital content – whether they own the content or not.
 
-Authorship or copyright is **not** a requirement to create or use an identifier. But **an identifier is a requirement** to communicate and agree on authorship, origin, copyright, and other information.
+Authorship or copyright is **not** a requirement to create or use a content code. But shared content-based identification is a requirement to communicate and agree on authorship, origin, copyright, and other information.
 
-Technology allows us to map **identifiers to digital content** without requiring an
+Technology allows us to map **codes to digital content** without requiring an
 intermediary by using open, standardized fingerprinting algorithms.
 
-Open and accessible **standard identifiers**, designed to manage small and sometimes transient pieces of digital content are fundamental for transactions and sales activities in our increasingly heterogeneous media environment.
+Open and accessible **standard content codes**, designed to manage small and sometimes transient pieces of digital content are fundamental for transactions and sales activities in our increasingly heterogeneous media environment.
 
-By using standardized, decentralized, algorithmic identifiers for digital content, all ecosystem participants can engage more efficiently in content-related transactions.
+By using standardized, decentralized, algorithmic codes for digital content, all ecosystem participants can engage more efficiently in content-related transactions.
 
 ## Key Features and Differentiators
 
@@ -67,7 +67,7 @@ By using standardized, decentralized, algorithmic identifiers for digital conten
 
 ## How it works
 
-**ISCC** identifiers are generated algorithmically **from the content itself**. Content files are processed to build the identifier. The ISCC does not have to be manually assigned, neither does it have to be carried around or embedded within the content. The content itself is the source and authority of the **ISCC-CODE**.
+**ISCC-CODEs** are generated algorithmically **from the content itself**. Content files are processed to build the code. The ISCC does not have to be manually assigned, neither does it have to be carried around or embedded within the content. The content itself is the source and authority of the **ISCC-CODE**.
 
-The **ISCC-CODE** is a unique, hierarchically structured, composite identifier. It is built from a generic and balanced mix of content-derived, locality-sensitive and similarity-preserving hashes generated from metadata and the content itself.
+The **ISCC-CODE** is a unique, hierarchically structured, composite content fingerprint. It is built from a generic and balanced mix of content-derived, locality-sensitive and similarity-preserving hashes generated from metadata and the content itself.
 

--- a/docs/license.md
+++ b/docs/license.md
@@ -19,7 +19,9 @@ This wide ISCC-SUM identifies the documentation source tree generated with
 
 The ISCC documentation on this site is licensed under **Creative Commons Attribution 4.0 International (CC BY 4.0)**.
 
-Copyright © 2016-2026 The Authors, Content Blockchain Project
+Copyright © 2016-2026 Titusz Pan and contributors.
+
+Published by the ISCC Foundation.
 
 <a rel="license" href="https://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
 

--- a/docs/license.md
+++ b/docs/license.md
@@ -7,7 +7,7 @@ icon: lucide/scale
 
 <!-- iscc-sum:start -->
 
-**Documentation source ISCC-SUM**: `ISCC:K4AE2KKH4WSOSSYML43ORTKHNCRTLR6E4CZXKUBPLPZTTHHAKB7QNPI`
+**Documentation source ISCC-SUM**: `ISCC:K4AE2KKH4WSOSSYML43ORTKHNCRTLX3L32XPGLRKRIHHW5LIL5OL4PA`
 
 This wide ISCC-SUM identifies the documentation source tree generated with
 `iscc-sum --tree docs`. The license page itself is excluded from the tree via
@@ -19,7 +19,7 @@ This wide ISCC-SUM identifies the documentation source tree generated with
 
 The ISCC documentation on this site is licensed under **Creative Commons Attribution 4.0 International (CC BY 4.0)**.
 
-Copyright © 2016 - 2020 The Authors, Content Blockchain Project
+Copyright © 2016-2026 The Authors, Content Blockchain Project
 
 <a rel="license" href="https://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -15,7 +15,7 @@ icon: lucide/book-open
 
 ## Abstract
 
-The **International Standard Content Code (ISCC)**, is an open and decentralized digital media identifier. An ISCC can be created from digital content and its basic metadata by anybody who follows the procedures of the ISCC specification or by using open source software that supports ISCC creation [conforming to the ISCC specification](#conformance-testing).
+The **International Standard Content Code (ISCC)** is an open and decentralized digital media code. An ISCC can be created from digital content and its basic metadata by anybody who follows the procedures of the ISCC specification or by using open source software that supports ISCC creation [conforming to the ISCC specification](#conformance-testing).
 
 ## Note to Readers
 
@@ -33,7 +33,7 @@ Public review, discussion and contributions are welcome.
 
     This page preserves the historical ISCC Version 1.1 specification material for URL continuity and reference. For current implementation guidance see [iscc-core](https://github.com/iscc/iscc-core) and [iscc-sdk](https://github.com/iscc/iscc-sdk). For the standardized specification see [ISO 24138:2024](https://www.iso.org/standard/77899.html).
 
-This document proposes an open and vendor neutral ISCC standard and describes the technical procedures to create and manage ISCC identifiers. The first version of this document resulted from a prototyping project by the [Content Blockchain Project](https://content-blockchain.org) and received funding from the [Google Digital News Initiative (DNI)](https://digitalnewsinitiative.com/dni-projects/content-blockchain-project/). The content of this document results from a voluntary effort of the authors with an open and public consensus process.
+This document proposes an open and vendor neutral ISCC standard and describes the technical procedures to create and manage ISCC codes. The first version of this document resulted from a prototyping project by the [Content Blockchain Project](https://content-blockchain.org) and received funding from the [Google Digital News Initiative (DNI)](https://digitalnewsinitiative.com/dni-projects/content-blockchain-project/). The content of this document results from a voluntary effort of the authors with an open and public consensus process.
 
 ## Conventions and Terminology
 
@@ -73,7 +73,7 @@ ISCC Digest:
 
 ## Introduction
 
-An ISCC permanently identifies content at multiple levels of *granularity*. It is algorithmically generated from basic metadata and the contents of a digital media object. It is designed for being registered and stored on a public and decentralized blockchain. An ISCC for a media object can be created and registered by the content author, a publisher, a service provider or anybody else. By itself the ISCC and its basic registration on a blockchain does not make any statement or claim about authorship or ownership of the identified content.
+An ISCC provides content-based identification at multiple levels of *granularity*. It is algorithmically generated from basic metadata and the contents of a digital media object. It is designed for being registered and stored on a public and decentralized blockchain. An ISCC for a media object can be created and registered by the content author, a publisher, a service provider or anybody else. By itself the ISCC and its basic registration on a blockchain does not make any statement or claim about authorship or ownership of the identified content.
 
 ## ISCC Structure
 
@@ -329,7 +329,7 @@ Applications may carry, store, and process the leaf node hashes for advanced str
 
 ## ISCC Metadata
 
-As a generic content identifier, the ISCC makes minimal assumptions about metadata that must or should be supplied together with an ISCC. The RECOMMENDED data-interchange format for ISCC metadata is [JSON](https://www.json.org/). We distinguish between **Basic Metadata** and **Extended Metadata**:
+As a generic content code, the ISCC makes minimal assumptions about metadata that must or should be supplied together with an ISCC. The RECOMMENDED data-interchange format for ISCC metadata is [JSON](https://www.json.org/). We distinguish between **Basic Metadata** and **Extended Metadata**:
 
 ### Basic Metadata
 
@@ -361,13 +361,13 @@ Extended metadata entries MUST be wrapped in JSON object of the following struct
 
 ## ISCC Registration
 
-The ISCC is a decentralized identifier. ISCCs can be generated for content by anybody who has access to the content. Because of the clustering properties of its components, the ISCC provides utility in data interchange and de-duplication scenarios even without a global registry. There is no central authority for the registration of ISCC codes or certification of content authorship.
+The ISCC is a decentralized content code. ISCCs can be generated for content by anybody who has access to the content. Because of the clustering properties of its components, the ISCC provides utility in data interchange and de-duplication scenarios even without a global registry. There is no central authority for the registration of ISCC codes or certification of content authorship.
 
 As an open system, the ISCC allows any person or organization to offer ISCC registration services as they see fit and without the need to ask anyone for permission. This also presumes that no person or organization may claim exclusive authority about ISCC registration.
 
 ### Blockchain Registry
 
-To properly address the questions of identifier uniqueness, ownership and authentication within the ISCC Standard, the assignment of a set of canonical blockchain is a requirement. The distributed nature of blockchains are a perfect fit for long-term persistent identifier registration and resolver services.
+To properly address the questions of code uniqueness, ownership and authentication within the ISCC Standard, the assignment of a set of canonical blockchain is a requirement. The distributed nature of blockchains are a perfect fit for long-term persistent code registration and resolver services.
 
 **The assignment of a set of canonical blockchains is NOT YET part of this specification.**
 
@@ -395,7 +395,7 @@ Applications MAY embed ISCC codes that have side effects if they specify a proce
 
 !!! note "Provisional Section"
 
-    The ISCC URI Scheme and link-resolver details ultimately depend on identifier registration, ownership, uniqueness and governance related decisions which are not yet part of this specification. See also: [Blockchain Registry](#blockchain-registry).
+    The ISCC URI Scheme and link-resolver details ultimately depend on code registration, ownership, uniqueness and governance related decisions which are not yet part of this specification. See also: [Blockchain Registry](#blockchain-registry).
 
 The purpose of the ISCC URI scheme based on [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt) is to enable users to discover information like metadata or license offerings from an ISCC marked content by clicking a link on a webpage or by scanning a QR-Code.
 
@@ -447,7 +447,7 @@ See also: [Base-ISCC Decoding reference code](https://github.com/iscc/iscc-codes
 
 ### Content Normalization
 
-The ISCC standardizes some content normalization procedures to support reproducible and stable identifiers. Following the list of normalization functions that MUST be provided by a conforming implementation.
+The ISCC standardizes some content normalization procedures to support reproducible and stable codes. Following the list of normalization functions that MUST be provided by a conforming implementation.
 
 #### text_trim
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,5 +1,5 @@
 [project]
-site_name = "ISCC - Content Codes"
+site_name = "iscc-codes"
 site_description = "International Standard Content Code - Specification"
 site_author = "Titusz Pan"
 site_url = "https://iscc.codes"


### PR DESCRIPTION
## Summary

- update the license page copyright year range to 2016-2026
- shorten the site/home navigation label to `iscc-codes`, matching the pattern used by `iscc-schema`
- change the homepage tagline to “Modern and open Content-Based Identification”
- replace ISCC-specific “identifier” wording with “code”, “content code”, “content fingerprint”, or “content-based identification” where we are talking about ISCC-CODEs
- keep references to established external identifier systems where the text is explicitly discussing ISBN/DOI/Handle-style identifiers
- refresh the automated documentation ISCC-SUM stamp after the docs copy changes

## Test plan

- `uv run --group dev python scripts/update_iscc_stamp.py --check`
- `uv run --group dev prek run --all-files`
- `uv run python scripts/check_site_paths.py`
- `uv run zensical build --clean`
- `uv run python scripts/check_site_paths.py --site-dir site`
- `git diff --check`