### PR TITLE
docs: update web demo URL to web.iscc.io

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ code for any text, image, audio, or video. Anyone can derive the same **ISCC-COD
 content, with no registry and no assignment step.
 
 [Learn how it works](concept.md){ .iscc-btn .iscc-btn--primary }
-[Try it live](https://demo.iscc.io){ .iscc-btn }
+[Try it live](https://web.iscc.io){ .iscc-btn }
 
 *Open source · ISO 24138:2024 · maintained by the [ISCC Foundation](https://iscc.io)*
 
@@ -80,7 +80,7 @@ Each unit is a compact, similarity-preserving hash.
 
 ## Try it
 
-- **Web demo:** <https://demo.iscc.io>
+- **Web demo:** <https://web.iscc.io>
 - **Playground:** <https://huggingface.co/spaces/iscc/iscc-playground>
 
 ## Developer entry points

--- a/docs/license.md
+++ b/docs/license.md
@@ -7,7 +7,7 @@ icon: lucide/scale
 
 <!-- iscc-sum:start -->
 
-**Documentation source ISCC-SUM**: `ISCC:K4AEK2KH4GCOSSYMKR3ORSLHNCRTCBBWM7JO7NF3NLKD2I66D27A2MA`
+**Documentation source ISCC-SUM**: `ISCC:K4AEK2KH4GCOSSYMKR3ORSLHNCRTD2G3SFYPHJUHGIR6TO6REZHOYXQ`
 
 This wide ISCC-SUM identifies the documentation source tree generated with
 `iscc-sum --tree docs`. The license page itself is excluded from the tree via

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -57,7 +57,7 @@ Every repository below is developed in the open under the **Apache-2.0** license
 <div class="iscc-repos">
 <a class="iscc-repo" href="https://github.com/iscc/iscc-web">
 <span class="iscc-repo__name">iscc-web</span><span class="iscc-badge iscc-badge--stable">Stable</span>
-<span class="iscc-repo__desc">REST API service for ISCC generation. Powers the public web demo at demo.iscc.io.</span>
+<span class="iscc-repo__desc">REST API service for ISCC generation. Powers the public web demo at web.iscc.io.</span>
 <span class="iscc-repo__cta"><svg class="iscc-repo__icon" viewBox="0 0 16 16" aria-hidden="true"><use href="#gh-mark"></use></svg>View on GitHub &rarr;</span>
 </a>
 <a class="iscc-repo" href="https://github.com/iscc/iscc-hub">
@@ -115,7 +115,7 @@ Every repository below is developed in the open under the **Apache-2.0** license
 Three million book covers from the Amazon Reviews'23 dataset, indexed and searchable through ISCC
 similarity matching.
 
-### [ISCC Web Demo](https://demo.iscc.io/)
+### [ISCC Web Demo](https://web.iscc.io/)
 
 Minimal web application for generating ISCCs directly in the browser. Live instance of
 [iscc-web](https://github.com/iscc/iscc-web).


### PR DESCRIPTION
## Summary

The public demo at `demo.iscc.io` is deprecated. This updates all documentation references to the new demo host at `web.iscc.io`.

## Changes

- `docs/index.md`: "Try it live" button and "Web demo" link
- `docs/resources.md`: iscc-web repo card description and "ISCC Web Demo" resource link
- `docs/license.md`: regenerated documentation ISCC-SUM stamp (via hook)

## Validation

- `prek run --all-files` passes (stamp regenerated)
- `scripts/check_site_paths.py` passes
- `zensical build --clean` succeeds with no issues
